### PR TITLE
Handle rp2350 pio2 by using sdk pio_get_instance & PIO_IRQ_NUM

### DIFF
--- a/src/pio_usb.c
+++ b/src/pio_usb.c
@@ -283,10 +283,10 @@ static void configure_tx_channel(uint8_t ch, PIO pio, uint sm) {
 
 static void apply_config(pio_port_t *pp, const pio_usb_configuration_t *c,
                          root_port_t *port) {
-  pp->pio_usb_tx = c->pio_tx_num == 0 ? pio0 : pio1;
+  pp->pio_usb_tx = pio_get_instance(c->pio_tx_num);
   pp->sm_tx = c->sm_tx;
   pp->tx_ch = c->tx_ch;
-  pp->pio_usb_rx = c->pio_rx_num == 0 ? pio0 : pio1;
+  pp->pio_usb_rx = pio_get_instance(c->pio_rx_num);
   pp->sm_rx = c->sm_rx;
   pp->sm_eop = c->sm_eop;
   port->pin_dp = c->pin_dp;
@@ -336,7 +336,7 @@ void pio_usb_bus_init(pio_port_t *pp, const pio_usb_configuration_t *c,
                       root_port_t *root) {
   memset(root, 0, sizeof(root_port_t));
 
-  pp->pio_usb_tx = c->pio_tx_num == 0 ? pio0 : pio1;
+  pp->pio_usb_tx = pio_get_instance(c->pio_tx_num);
   dma_claim_mask(1<<c->tx_ch);
   configure_tx_channel(c->tx_ch, pp->pio_usb_tx, c->sm_tx);
 

--- a/src/pio_usb_device.c
+++ b/src/pio_usb_device.c
@@ -291,7 +291,7 @@ usb_device_t *pio_usb_device_init(const pio_usb_configuration_t *c,
   // configure PIOx_IRQ_0 to detect packet receive start
   pio_set_irqn_source_enabled(pp->pio_usb_rx, 0, pis_interrupt0 + IRQ_RX_START,
                               true);
-  pp->device_rx_irq_num = (pp->pio_usb_rx == pio0) ? PIO0_IRQ_0 : PIO1_IRQ_0;
+  pp->device_rx_irq_num = PIO_IRQ_NUM(pp->pio_usb_rx, 0);
   irq_set_exclusive_handler(pp->device_rx_irq_num, usb_device_packet_handler);
   irq_set_enabled(pp->device_rx_irq_num, true);
 

--- a/src/sdk_compat.h
+++ b/src/sdk_compat.h
@@ -6,6 +6,17 @@ static __always_inline void pio_sm_set_jmp_pin(PIO pio, uint sm, uint jmp_pin) {
       (pio->sm[sm].execctrl & ~PIO_SM0_EXECCTRL_JMP_PIN_BITS) |
       (jmp_pin << PIO_SM0_EXECCTRL_JMP_PIN_LSB);
 }
+
+static_assert(PIO1_BASE - PIO0_BASE == (1u << 20), "hardware layout mismatch");
+#define PIO_INSTANCE(instance) ((pio_hw_t *)(PIO0_BASE + (instance) * (1u << 20)))
+static __always_inline PIO pio_get_instance(uint instance) {
+    return PIO_INSTANCE(instance);
+}
+
+#define PIO_NUM(pio) (((uintptr_t)(pio) - PIO0_BASE) >> 20)
+#define NUM_PIO_IRQS (2u)
+#define PIO_IRQ_NUM(pio, irqn) (PIO0_IRQ_0 + NUM_PIO_IRQS * PIO_NUM(pio) + (irqn))
+
 #endif
 
 #if PICO_SDK_VERSION_MAJOR < 2 || (PICO_SDK_VERSION_MAJOR == 2 && PICO_SDK_VERSION_MINOR < 1)


### PR DESCRIPTION
Before this change, only pio0/1 was usable for USB Host.

I'll also PR this upstream.